### PR TITLE
Add count to downlink 'pong' message

### DIFF
--- a/src/main/java/io/drogue/iot/demo/Processor.java
+++ b/src/main/java/io/drogue/iot/demo/Processor.java
@@ -62,14 +62,16 @@ public class Processor {
 
         LOG.info("Received payload: {}", payload);
 
-        if (!event.getPayload().startsWith("ping:")) {
+        if (!payload.startsWith("ping:")) {
             return null;
         }
+
+        var responsePayload = response + payload.substring(payload.indexOf(':'));
 
         var command = new DeviceCommand();
 
         command.setDeviceId(event.getDeviceId());
-        command.setPayload(this.response.getBytes(StandardCharsets.UTF_8));
+        command.setPayload(responsePayload.getBytes(StandardCharsets.UTF_8));
 
         return command;
 


### PR DESCRIPTION
This commit adds the count from the received uplink payload, like
`ping:14`, to the downlink response message which would become
`pong:14`.

The motivation for this is that it is easier to identify the which pong
is received in the device console output.

For example, instead of just seeing:
```console
INFO  Received 4 bytes from uplink:
pong
```
The count will now also be included:
```console
INFO  Received 7 bytes from uplink:
pong:14
```